### PR TITLE
construct path to PTN file

### DIFF
--- a/binary_utilities.py
+++ b/binary_utilities.py
@@ -74,7 +74,7 @@ def get_bar_code(pattern):
 def get_pad_code(bank_letter, pad_number):
     bank = ord(bank_letter.lower()) - constants.ascii_character_offset
     code = str(hex((bank * constants.pads_per_bank) + int(pad_number)))[2:]
-    return add_padding(code, 3)
+    return add_padding(int(code, 16), 3)
 
 
 def gen_pad_bank(pad_code, bank_switch):


### PR DESCRIPTION
I am reasonably sure this fixes #8 because it maps from the hex code that identifies the pattern back to the corresponding int value. This is based on a single case where the constructed hex returned `0f` where it needed to be `15`, as discussed in #7. Untested!